### PR TITLE
don't add a build if one doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ pkg
 #
 # For MacOS:
 #
-#.DS_Store
+.DS_Store
 #
 # For TextMate
 #*.tmproj
@@ -39,4 +39,4 @@ pkg
 #.\#*
 #
 # For vim:
-#*.swp
+*.swp

--- a/lib/bumper/version.rb
+++ b/lib/bumper/version.rb
@@ -25,7 +25,7 @@ module Bumper
       version = @v[part] = @v[part].succ
       
       return version if part == :build
-      @v[:build] = '0'
+      @v[:build] = '0' if @v[:build]
       return version if part == :revision
       @v[:revision] = 0
       return version if part == :minor

--- a/test/test_version_bumper.rb
+++ b/test/test_version_bumper.rb
@@ -46,4 +46,10 @@ class TestVersionBumper < MiniTest::Unit::TestCase
     assert_equal '0', v.build
     assert_equal '2.0.0.0', v.to_s
   end
+
+  def test_that_bumping_major_without_build_does_not_add_build
+    v = Bumper::Version.new('0.0.0')
+    v.bump_major
+    assert_equal '1.0.0', v.to_s
+  end
 end


### PR DESCRIPTION
i started using version_bumper with albacore today, and i noticed that it was automatically adding a build .0 to the version when bumping any other portion of the version. for example: "0.2.2".bump_revision #=> "0.2.3.0"

ruby projects generally don't use a .build (since there is no "build" process for a ruby project), so I added a test and modified the code so that it won't add a build number to the version when bumping any other portion of it. so now "0.2.2".bump_revision #=> "0.2.3"
